### PR TITLE
feat: Send line numbers instead of code itself for improved context

### DIFF
--- a/lua/opencode.lua
+++ b/lua/opencode.lua
@@ -29,13 +29,16 @@ function M.send(prompt, opts)
   local mode = vim.fn.mode()
   local is_visual = mode:match("[vV\22]")
   if is_visual then
-    -- Prepend visual mode selection
-    -- Would this be better as an @selection placeholder...?
-    -- Probably not - annoying to add the placeholder to every prompt, especially when it's conditional
-    -- TODO: include the file name and line numbers in the prompt? So opencode doesn't have to grep for it.
-    local lines = vim.fn.getregion(vim.fn.getpos("v"), vim.fn.getpos("."), { type = mode })
-    local selected_text = table.concat(lines, "\n")
-    prompt = selected_text .. "\n\n" .. prompt
+    -- Prepend file path and selected line range
+    local start_pos = vim.fn.getpos('v')
+    local end_pos = vim.fn.getpos('.')
+    local start_line = start_pos[2]
+    local end_line = end_pos[2]
+    if start_line > end_line then
+      start_line, end_line = end_line, start_line
+    end
+    local file_path = vim.api.nvim_buf_get_name(0)
+    prompt = string.format("%s:L%d-%d\n\n%s", file_path, start_line, end_line, prompt)
     -- Exit visual mode now that we've "consumed" the selection
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", true)
   end


### PR DESCRIPTION
Previously, the "Explain this code" feature would send only the selected code snippet, which often lost important context about where the code was located and how it was used.

This change updates the feature to send the file name along with the relevant line numbers (e.g., app/service/task_service.go:L10-20) instead of the code itself. By leveraging opencode's file grepping capabilities, this approach provides more precise context to the assistant, improving the quality of explanations and reducing the need for users to manually specify file locations.
