### PR TITLE
use exact match for find instead of pattern matching

### DIFF
--- a/lua/opencode.lua
+++ b/lua/opencode.lua
@@ -23,7 +23,7 @@ function M.prompt(prompt, opts)
   for _, pid in ipairs(server.get_all_pids()) do
     local opencode_cwd = server.get_cwd(pid)
     -- CWDs match exactly, or opencode's CWD is under neovim's CWD.
-    if opencode_cwd and opencode_cwd:find(vim.fn.getcwd()) == 1 then
+    if opencode_cwd and string.find(opencode_cwd, vim.fn.getcwd(), 1, true) == 1 then
       server_pid = pid
       break
     end


### PR DESCRIPTION
`find` uses pattern matching instead of exact matching. This leads to problems when a path contains special characters used for expressions (like dashes). by using the given options, exact matching is used.
