### PR TITLE
feat: add model option

### DIFF
--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -12,6 +12,10 @@ vim.g.opencode_opts = vim.g.opencode_opts
 ---The embedded terminal will automatically launch `opencode` with this; launch external instances with `opencode --port <port>`.
 ---@field port? number
 ---
+---The model to use with `opencode`.
+---If specified, will pass `--model <model>` to the opencode binary.
+---@field model? string
+---
 ---Automatically reload buffers edited by `opencode` in real-time.
 ---Requires `vim.opt.autoread = true`.
 ---@field auto_reload? boolean

--- a/lua/opencode/terminal.lua
+++ b/lua/opencode/terminal.lua
@@ -3,8 +3,15 @@ local M = {}
 ---The `opencode` command, with `--port` if specified in config.
 ---@return string
 function M.cmd()
-  local port = require("opencode.config").opts.port
-  return "opencode" .. (port and (" --port " .. port) or "")
+  local opts = require("opencode.config").opts
+  local cmd = "opencode"
+  if opts.port then
+    cmd = cmd .. " --port " .. opts.port
+  end
+  if opts.model then
+    cmd = cmd .. " --model " .. opts.model
+  end
+  return cmd
 end
 
 local function safe_snacks_terminal()


### PR DESCRIPTION
We can configure a global model for the `opencode` cli to launch with.