### PR TITLE
Add example keymaps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ https://github.com/user-attachments/assets/340ce139-173c-4e81-b39a-f089862db9ce
     -- Required for `toggle()`.
     { "folke/snacks.nvim", opts = { input = {}, picker = {} } },
   },
+  keys = {
+    -- Recommended/example keymaps
+    { "<leader>oa", function() require("opencode").ask("@this: ", { submit = true }) end, mode = { "n", "x" }, desc = "Ask about this" },
+    { "<leader>o+", function() require("opencode").prompt("@this") end, mode = { "n", "x" }, desc = "Add this" },
+    { "<leader>os", function() require("opencode").select() end, mode = { "n", "x" }, desc = "Select prompt" },
+    { "<leader>ot", function() require("opencode").toggle() end, desc = "Toggle embedded" },
+    { "<leader>on", function() require("opencode").command("session_new") end, desc = "New session" },
+    { "<leader>oi", function() require("opencode").command("session_interrupt") end, desc = "Interrupt session" },
+    { "<S-C-u>", function() require("opencode").command("messages_half_page_up") end, desc = "Messages half page up" },                                                                                                                
+    { "<S-C-d>", function() require("opencode").command("messages_half_page_down") end, desc = "Messages half page down" },
+  },
   config = function()
     vim.g.opencode_opts = {
       -- Your configuration, if any — see `lua/opencode/config.lua`
@@ -35,16 +46,6 @@ https://github.com/user-attachments/assets/340ce139-173c-4e81-b39a-f089862db9ce
 
     -- Required for `vim.g.opencode_opts.auto_reload`
     vim.opt.autoread = true
-
-    -- Recommended/example keymaps
-    vim.keymap.set({ "n", "x" }, "<leader>oa", function() require("opencode").ask("@this: ", { submit = true }) end, { desc = "Ask about this" })
-    vim.keymap.set({ "n", "x" }, "<leader>o+", function() require("opencode").prompt("@this") end, { desc = "Add this" })
-    vim.keymap.set({ "n", "x" }, "<leader>os", function() require("opencode").select() end, { desc = "Select prompt" })
-    vim.keymap.set("n", "<leader>ot", function() require("opencode").toggle() end, { desc = "Toggle embedded" })
-    vim.keymap.set("n", "<leader>on", function() require("opencode").command("session_new") end, { desc = "New session" })
-    vim.keymap.set("n", "<leader>oi", function() require("opencode").command("session_interrupt") end, { desc = "Interrupt session" })
-    vim.keymap.set("n", "<S-C-u>",    function() require("opencode").command("messages_half_page_up") end, { desc = "Messages half page up" })
-    vim.keymap.set("n", "<S-C-d>",    function() require("opencode").command("messages_half_page_down") end, { desc = "Messages half page down" })
   end,
 }
 ```


### PR DESCRIPTION
This is in fact the recommended way to setup key bindings in lazy nvim, because then it works with lazy loading (lazy nvim is aware of the key bindings set this way and can lazy load the plugin on demand)