### PR TITLE
feat(provider): add kitty provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ If `opencode.nvim` can't find an existing `opencode`, it uses the configured pro
 ```lua
 vim.g.opencode_opts = {
   provider = {
-    enabled = "snacks", -- Default if `snacks.terminal` is available and enabled.
+    enabled = "snacks",
     snacks = {
-      -- Customize `snacks.terminal` to your liking.
+      -- ...
     }
   }
 }
@@ -128,17 +128,9 @@ vim.g.opencode_opts = {
 ```lua
 vim.g.opencode_opts = {
   provider = {
-    enabled = "kitty", -- Default when running inside a `kitty` session with remote control enabled.
+    enabled = "kitty",
     kitty = {
-      -- Location where `opencode` instance should be opened
-      -- Possible values:
-      -- * https://sw.kovidgoyal.net/kitty/launch/#cmdoption-launch-location
-      -- * `tab`
-      -- * `os-window`
-      location = "default",
-      -- Optional password for kitty remote control
-      -- https://sw.kovidgoyal.net/kitty/remote-control/#cmdoption-kitten-password
-      password = nil,
+      -- ...
     }
   }
 }
@@ -175,9 +167,9 @@ listen_on unix:/tmp/kitty
 ```lua
 vim.g.opencode_opts = {
   provider = {
-    enabled = "tmux", -- Default if inside a `tmux` session.
+    enabled = "tmux",
     tmux = {
-      options = "-h", -- Options to pass to `tmux split-window`.
+      -- ...
     }
   }
 }

--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -140,7 +140,7 @@ local defaults = {
       },
     },
     kitty = {
-      location = "default", --"after" | "before" | "default" | "first" | "hsplit" | "last" | "neighbor" | "split" | "vsplit" | "tab" | "os-window"
+      location = "default",
     },
     tmux = {
       options = "-h", -- Open in a horizontal split

--- a/lua/opencode/provider/init.lua
+++ b/lua/opencode/provider/init.lua
@@ -39,10 +39,10 @@
 ---The built-in provider to use, or `false` for none.
 ---Default order:
 ---  - `"snacks"` if `snacks.terminal` is available and enabled
----  - `"kitty"` if in a kitty session with remote control enabled,
+---  - `"kitty"` if in a `kitty` session with remote control enabled
 ---  - `"tmux"` if in a `tmux` session
 ---  - `false`
----@field enabled? "snacks"|"tmux"|false
+---@field enabled? "snacks"|"kitty"|"tmux"|false
 ---
 ---@field snacks? opencode.provider.snacks.Opts
 ---@field kitty? opencode.provider.kitty.Opts

--- a/lua/opencode/provider/kitty.lua
+++ b/lua/opencode/provider/kitty.lua
@@ -1,23 +1,23 @@
 ---Provide `opencode` in a `kitty` terminal instance.
----Works only when kitty remote control is enabled.
+---Requires [kitty remote control](https://sw.kovidgoyal.net/kitty/remote-control/#remote-control-via-a-socket) to be enabled.
 ---@class opencode.provider.Kitty : opencode.Provider
 ---
 ---@field opts opencode.provider.kitty.Opts
----@field window_id? number The kitty window ID where `opencode` is running (internal use only)
+---@field window_id? number The `kitty` window ID where `opencode` is running (internal use only).
 local Kitty = {}
 Kitty.__index = Kitty
 Kitty.name = "kitty"
 
 ---@class opencode.provider.kitty.Opts
 ---
----Location where `opencode` instance should be opened
+---Location where `opencode` instance should be opened.
 ---Possible values:
 --- * https://sw.kovidgoyal.net/kitty/launch/#cmdoption-launch-location
 --- * `tab`
 --- * `os-window`
 ---@field location? "after" | "before" | "default" | "first" | "hsplit" | "last" | "neighbor" | "split" | "vsplit" | "tab" | "os-window"
 ---
----Optional password for kitty remote control
+---Optional password for `kitty` remote control.
 ---https://sw.kovidgoyal.net/kitty/remote-control/#cmdoption-kitten-password
 ---@field password? string
 ---
@@ -32,16 +32,16 @@ function Kitty.new(opts)
   return self
 end
 
----Health check for the kitty provider
-function Kitty:health()
+---Check if `kitty` remote control is available.
+function Kitty.health()
   if vim.env.KITTY_LISTEN_ON and #vim.env.KITTY_LISTEN_ON > 0 then
     return true
   else
-    return "KITTY_LISTEN_ON environment variable is not set", "Enable remote control in kitty"
+    return "KITTY_LISTEN_ON environment variable is not set.", "Enable remote control in `kitty`."
   end
 end
 
----Execute a kitty remote control command
+---Execute a `kitty` remote control command.
 ---@param args string[] Arguments to pass to kitty @
 ---@return string|nil output, number|nil code
 function Kitty:kitty_exec(args)
@@ -65,8 +65,8 @@ function Kitty:kitty_exec(args)
   return output, code
 end
 
----Get the window ID where opencode is running
----@return number|nil window_id The kitty window ID
+---Get the `kitty` window ID where `opencode` is running.
+---@return number|nil window_id
 function Kitty:get_window_id()
   -- Return cached window_id if it still exists
   if self.window_id then
@@ -128,7 +128,7 @@ function Kitty:get_window_id()
   return nil
 end
 
----Toggle opencode in kitty window
+---Toggle `opencode` in window.
 function Kitty:toggle()
   local ok, err = self:health()
   if ok ~= true then
@@ -145,7 +145,7 @@ function Kitty:toggle()
   end
 end
 
----Start opencode in kitty window
+---Start `opencode` in window.
 function Kitty:start()
   local ok, err = self:health()
   if ok ~= true then
@@ -197,7 +197,7 @@ function Kitty:start()
   end
 end
 
----Stop opencode in kitty window
+---Stop `opencode` window.
 function Kitty:stop()
   local window_id = self:get_window_id()
   if window_id then
@@ -208,7 +208,7 @@ function Kitty:stop()
   end
 end
 
----Show opencode window
+---Show `opencode` window.
 function Kitty:show()
   local window_id = self:get_window_id()
   if not window_id then

--- a/lua/opencode/provider/snacks.lua
+++ b/lua/opencode/provider/snacks.lua
@@ -6,7 +6,6 @@
 ---@field opts snacks.terminal.Opts
 local Snacks = {}
 Snacks.__index = Snacks
-
 Snacks.name = "snacks"
 
 ---@class opencode.provider.snacks.Opts : snacks.terminal.Opts

--- a/lua/opencode/provider/tmux.lua
+++ b/lua/opencode/provider/tmux.lua
@@ -1,12 +1,11 @@
----Provide `opencode` in a `tmux` pane in the current window.
----Works only in Unix systems.
+---Provide `opencode` in a [`tmux`](https://github.com/tmux/tmux) pane in the current window.
+---Requires Unix system.
 ---@class opencode.provider.Tmux : opencode.Provider
 ---
 ---@field opts opencode.provider.tmux.Opts
----@field pane_id? string The tmux pane ID where `opencode` is running (internal use only).
+---@field pane_id? string The `tmux` pane ID where `opencode` is running (internal use only).
 local Tmux = {}
 Tmux.__index = Tmux
-
 Tmux.name = "tmux"
 
 ---@class opencode.provider.tmux.Opts
@@ -44,8 +43,8 @@ function Tmux.health()
   return true
 end
 
----Get the pane ID where `opencode` is running.
----@return string|nil pane_id The tmux pane ID
+---Get the `tmux` pane ID where `opencode` is running.
+---@return string|nil pane_id
 function Tmux:get_pane_id()
   local ok = self.health()
   if ok ~= true then
@@ -72,7 +71,7 @@ function Tmux:get_pane_id()
   return self.pane_id
 end
 
----Create or kill the `opencode` tmux pane.
+---Create or kill the `opencode` pane.
 function Tmux:toggle()
   local pane_id = self:get_pane_id()
   if pane_id then
@@ -82,7 +81,7 @@ function Tmux:toggle()
   end
 end
 
----Start `opencode` in tmux pane.
+---Start `opencode` in pane.
 function Tmux:start()
   local pane_id = self:get_pane_id()
   if not pane_id then
@@ -101,7 +100,7 @@ function Tmux:stop()
   end
 end
 
----No-op for tmux - too many different implementations that may conflict with user's preferences.
+---No-op for `tmux` - too many different implementations that may conflict with user's preferences.
 function Tmux:show() end
 
 return Tmux


### PR DESCRIPTION
Add a new provider for kitty terminal emulator.
* The `location`[^1] where the new terminal instance running opencode
should be opened is configurable.
* Allow specifying a password[^2].

[^1]: https://sw.kovidgoyal.net/kitty/launch/#cmdoption-launch-location
[^2]: https://sw.kovidgoyal.net/kitty/remote-control/#cmdoption-kitten-password
