### PR TITLE
Add timer_closed flag to poll_for_port function

### DIFF
--- a/lua/opencode/cli/server.lua
+++ b/lua/opencode/cli/server.lua
@@ -121,6 +121,7 @@ end
 local function poll_for_port(fn, callback)
   local retries = 0
   local timer = vim.uv.new_timer()
+  local timer_closed = false
   -- TODO: Suddenly with opentui release,
   -- on startup it seems the port can be available but too quickly calling it will no-op?
   -- Increasing delay for now to mitigate. But more reliable fix may be needed.
@@ -128,8 +129,12 @@ local function poll_for_port(fn, callback)
     500,
     500,
     vim.schedule_wrap(function()
+      if timer_closed then
+        return
+      end
       local ok, find_port_result = pcall(fn)
       if ok or retries >= 5 then
+        timer_closed = true
         timer:stop()
         timer:close()
         callback(ok, find_port_result)


### PR DESCRIPTION
Added a flag to track if the timer is closed to prevent further execution.

Otherwise, whenver i type shortcut like `<C-x>` to trigger opencode panel for the first time, I saw this harmless error from neovim status line in x86 amd 64 cpu, although MacOS m3 pro chip is good without this issue:

```
No `opencode` processes — 
starting `opencode`…
Error executing vim.schedule lua callback: 
...hare/nvim/lazy/opencode.nvim/lua/opencode/cli/server.lua:134: handle 0x5d39ec3a5fa0 is  already closing
stack traceback:
        [C]: in function 'close'
        ...hare/nvim/lazy/opencode.nvim/lua/opencode/cli/server.lua:134: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```