### PR TITLE
Fix: Detect opencode process when running via Bun or Nix

### DIFF
--- a/lua/opencode/cli/server.lua
+++ b/lua/opencode/cli/server.lua
@@ -49,20 +49,20 @@ local function find_servers()
     if pid then
       -- Get CWD once per PID
       local cwd = exec("lsof -w -a -p " .. pid .. " -d cwd 2>/dev/null || true"):match("%s+(/.*)$")
-      
+
       if cwd then
         -- `-w` suppresses filesystem warnings (e.g. Docker FUSE)
         local lsof_output = exec("lsof -w -iTCP -sTCP:LISTEN -P -n -a -p " .. pid .. " 2>/dev/null || true")
-        
+
         if lsof_output ~= "" then
           for line in lsof_output:gmatch("[^\r\n]+") do
             local parts = vim.split(line, "%s+")
-            
+
             if parts[1] ~= "COMMAND" then -- Skip header
               local port = parts[9] and parts[9]:match(":(%d+)$") -- e.g. "127.0.0.1:12345" -> "12345"
               if port then
                 port = tonumber(port)
-                
+
                 table.insert(
                   servers,
                   ---@class Server


### PR DESCRIPTION
# Fix: Detect opencode process when running via Bun or Nix

## Problem

Closes #83

When `opencode` is installed via Nix or launched with Bun, the process name in `lsof` output appears as `bun` instead of `opencode`:

```bash
$ lsof -w -iTCP -sTCP:LISTEN -P -n | grep opencode
# No output - grep fails to find process

$ lsof -w -iTCP -sTCP:LISTEN -P -n | grep bun
bun  2368759 user  28u  IPv4 ... TCP 127.0.0.1:43085 (LISTEN)
```

This causes `find_servers()` to fail with "No \`opencode\` processes", even though opencode is running.

## Solution

Instead of using `lsof | grep opencode`, this PR:

1. Uses `pgrep -f 'opencode run'` to find PIDs by command line pattern
2. Uses `lsof` on specific PIDs to get their listening ports

This approach works regardless of:
- Installation method (npm, Bun, Nix, binary)
- Runtime (node, bun, standalone binary)
- Process name in system tools

## Testing

Tested with:
- ✅ Opencode installed via Nix (process name: `bun`)
- ✅ Multiple opencode instances in different directories
- ✅ Embedded opencode processes (child of Neovim)

## Compatibility

`pgrep` is part of `procps` (Linux) and `procps-ng` (most Unix systems), available by default on:
- Linux (all major distributions)
- macOS
- BSDs

Falls back to existing error message if `pgrep` is not found.