### PR TITLE
fix(server): skip invalid processes when discovering opencode servers

### DIFF
--- a/lua/opencode/cli/server.lua
+++ b/lua/opencode/cli/server.lua
@@ -161,8 +161,20 @@ local function find_servers()
     error("No `opencode` processes found", 0)
   end
 
+  -- Filter out processes that aren't valid opencode servers.
+  -- pgrep -f 'opencode' may match other processes (e.g., language servers
+  -- started by opencode) that have 'opencode' in their path or arguments.
   ---@type opencode.cli.server.Server[]
-  local servers = vim.tbl_map(populate_cwd, processes)
+  local servers = {}
+  for _, process in ipairs(processes) do
+    local ok, server = pcall(populate_cwd, process)
+    if ok then
+      table.insert(servers, server)
+    end
+  end
+  if #servers == 0 then
+    error("No valid `opencode` servers found", 0)
+  end
   return servers
 end
 


### PR DESCRIPTION
## Summary
- Fix server discovery failing when `pgrep -f 'opencode'` matches non-opencode processes (e.g., language servers started by opencode like elixir-ls at `~/.local/share/opencode/bin/elixir-ls-master/`)
## Problem
When discovering opencode servers, `find_servers()` uses `pgrep -f 'opencode'` which can match processes that have "opencode" in their path or arguments but aren't actual opencode servers. For example, the Elixir language server spawned by opencode:
```
beam.smp ... -extra /Users/jperi/.local/share/opencode/bin/elixir-ls-master/release/launch.exs
```
Previously, if any matched process failed the `/path` endpoint check, `find_servers()` would throw an error and abort entirely, preventing the plugin from finding valid opencode servers.
## Solution
Wrap `populate_cwd()` in `pcall()` and filter out processes that fail validation, rather than erroring out on the first failure. This allows the plugin to skip invalid processes and continue searching for valid opencode servers.

This patch has been working on my local setup, but I'm not sure if it's the "right" fix, so inputs welcome!

Maybe fixes #99
