### PR TITLE
fix: prevent extmark end_col from exceeding line length

### DIFF
--- a/lua/opencode/context.lua
+++ b/lua/opencode/context.lua
@@ -72,9 +72,15 @@ end
 ---@param buf integer
 ---@param range opencode.context.Range
 local function highlight(buf, range)
+  local end_row = range.to[1] - (range.kind == "line" and 0 or 1)
+  local end_col = nil
+  if range.kind ~= "line" then
+    local line = vim.api.nvim_buf_get_lines(buf, end_row, end_row + 1, false)[1] or ""
+    end_col = math.min(range.to[2] + 1, #line)
+  end
   vim.api.nvim_buf_set_extmark(buf, ns_id, range.from[1] - 1, range.from[2], {
-    end_row = range.to[1] - (range.kind == "line" and 0 or 1),
-    end_col = (range.kind ~= "line") and range.to[2] + 1 or nil,
+    end_row = end_row,
+    end_col = end_col,
     hl_group = "Visual",
   })
 end


### PR DESCRIPTION
## Summary

Fix `nvim_buf_set_extmark` error when highlighting visual selections that extend to or beyond the end of a line.

## Problem

The `highlight()` function in `context.lua` calculates `end_col` as `range.to[2] + 1`, but this can exceed the actual line length, causing Neovim to throw an error:

```
E5108: Error executing lua ...opencode.nvim/lua/opencode/context.lua:75: in function 'nvim_buf_set_extmark'
```

This occurs when:
- The cursor/selection is at the end of a line
- The selection ends on an empty line
- Virtual column positions extend beyond line content

## Solution

Clamp `end_col` to the actual line length using `math.min(range.to[2] + 1, #line)`.

## Testing

Tested by selecting code and pressing `go` (operator mode) - the error no longer occurs.