### PR TITLE
fix: only restore visual mode selection if input was spawned from visual mode

### DIFF
--- a/lua/opencode/context.lua
+++ b/lua/opencode/context.lua
@@ -104,7 +104,7 @@ end
 
 function Context:resume()
   self:clear()
-  if self.range then
+  if self.range ~= nil then
     vim.cmd("normal! gv")
   end
 end


### PR DESCRIPTION
The fix for this issue https://github.com/NickvanDyke/opencode.nvim/issues/97 was actually not enough. We should only restore visual selection if we were in a visual mode in a first place.

The issue is described in more details in this comment:
https://github.com/NickvanDyke/opencode.nvim/issues/97#issuecomment-3703980144

**PS.** Huge thanks for the great plugin.