### PR TITLE
fix: don't expect buffer to be loaded to add it to context

### DIFF
--- a/lua/opencode/context.lua
+++ b/lua/opencode/context.lua
@@ -24,7 +24,7 @@ local function last_used_valid_win()
   local latest_last_used = 0
   for _, win in ipairs(vim.api.nvim_list_wins()) do
     local buf = vim.api.nvim_win_get_buf(win)
-    if vim.api.nvim_buf_is_loaded(buf) and is_buf_valid(buf) then
+    if is_buf_valid(buf) then
       local last_used = vim.fn.getbufinfo(buf)[1].lastused or 0
       if last_used > latest_last_used then
         latest_last_used = last_used
@@ -309,7 +309,7 @@ function Context:visible_text()
   local visible = {}
   for _, win in ipairs(vim.api.nvim_list_wins()) do
     local buf = vim.api.nvim_win_get_buf(win)
-    if vim.api.nvim_buf_is_loaded(buf) and is_buf_valid(buf) then
+    if is_buf_valid(buf) then
       local start_line = vim.fn.line("w0", win)
       local end_line = vim.fn.line("w$", win)
       table.insert(


### PR DESCRIPTION
I am using a quickfix list in a following way:

- I use nvim-tree plugin, where I can mark multiple files with `m` key
- I have a special command which sends all of the marked files in a quickfix list (I use Ctrl+q hotkey for that, similarly to Telescope plugin) 
- Then I can make those ones available to opencode with `@quickfix` context alias

The issue: currently `opencode.nvim` expects those buffers to be loaded. Which is not guaranteed with such workflow. Here I try to retain this check in other scenarios, but I've removed it from the one which is used by a quickfix.

I hope I've explained it clearly!