### PR TITLE
Fix opencode command for kitty provider

### DIFF
--- a/lua/opencode/provider/kitty.lua
+++ b/lua/opencode/provider/kitty.lua
@@ -131,7 +131,10 @@ function Kitty:start()
     table.insert(launch_cmd, "--location=" .. location)
   end
 
-  table.insert(launch_cmd, self.cmd)
+  -- Split cmd string into separate arguments for kitty launch
+  for arg in self.cmd:gmatch("%S+") do
+    table.insert(launch_cmd, arg)
+  end
 
   local stdout, code = self:kitty_exec(launch_cmd)
 


### PR DESCRIPTION
Kitty requires the executable and any extra arguments to be provided as an array of values. Before this change it would try and execute "opencode --port" and state no such executable could be found

This fixes the issue for the kitty provider; unsure if other providers would need a similar fix