### PR TITLE
refactor(ui): simplify select rendering to avoid alignment issues

### DIFF
--- a/lua/opencode/ui/select.lua
+++ b/lua/opencode/ui/select.lua
@@ -183,17 +183,11 @@ function M.select(opts)
             table.insert(formatted, 2, { string.rep(" ", 18 - #item.name) })
             return formatted
           else
-            local indent = #tostring(#items) - #tostring(item.idx)
             if item.__group then
               local divider = string.rep("—", (80 - #item.name) / 2)
-              return string.rep(" ", indent) .. divider .. item.name .. divider
+              return divider .. item.name .. divider
             end
-            return ("%s[%s]%s%s"):format(
-              string.rep(" ", indent),
-              item.name,
-              string.rep(" ", 18 - #item.name),
-              item.text or ""
-            )
+            return ("[%s]%s%s"):format(item.name, string.rep(" ", 18 - #item.name), item.text or "")
           end
         end,
       }


### PR DESCRIPTION
## Summary
- Simplified the select rendering logic in `lua/opencode/ui/select.lua`
- Removed unnecessary indentation calculations that were causing alignment issues
- The change makes the code cleaner and more maintainable

## Changes
- Removed the `indent` variable calculation based on item index
- Simplified group divider rendering to remove unnecessary spacing
- Simplified regular item formatting to remove the leading spacing

This refactoring improves the visual alignment of the select UI and reduces code complexity.

For example, when using dressing+telescope as the implementation of vim.ui.select, this situation occurs.

<img width="562" height="219" alt="Xnip2026-01-13_03-00-44" src="https://github.com/user-attachments/assets/2ccabdcc-e58e-418f-a994-ae8b0eb3a91f" />
