### PR TITLE
feat(context): add `absolute_paths` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ programs.nixvim = {
 | `@marks`         | Global marks                                                |
 | `@grapple`       | [grapple.nvim](https://github.com/cbochs/grapple.nvim) tags |
 
+#### Absolute Paths
+
+By default, file paths in contexts are relative to Neovim's working directory. If `opencode` is running in a different directory, these relative paths may not resolve correctly.
+
+Set `absolute_paths = true` to use absolute file paths instead:
+
+```lua
+vim.g.opencode_opts = {
+  absolute_paths = true,
+}
+```
+
 ### Prompts
 
 Select or reference prompts to review, explain, and improve your code:

--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -18,6 +18,10 @@ vim.g.opencode_opts = vim.g.opencode_opts
 ---If set, `opencode.nvim` will append `--port <port>` to `provider.cmd` if not already present.
 ---@field port? number
 ---
+---Use absolute file paths instead of paths relative to Neovim's CWD.
+---Useful when `opencode` is running in a different directory than Neovim.
+---@field absolute_paths? boolean
+---
 ---Contexts to inject into prompts, keyed by their placeholder.
 ---@field contexts? table<string, fun(context: opencode.Context): string|nil>
 ---
@@ -45,6 +49,7 @@ vim.g.opencode_opts = vim.g.opencode_opts
 ---@type opencode.Opts
 local defaults = {
   port = nil,
+  absolute_paths = false,
   -- stylua: ignore
   contexts = {
     ["@this"] = function(context) return context:this() end,

--- a/lua/opencode/context.lua
+++ b/lua/opencode/context.lua
@@ -236,9 +236,12 @@ end
 function Context.format(args)
   local result = ""
   if (args.buf and is_buf_valid(args.buf)) or args.path then
-    local rel_path = vim.fn.fnamemodify(args.path or vim.api.nvim_buf_get_name(args.buf), ":.")
+    local raw_path = args.path or vim.api.nvim_buf_get_name(args.buf)
+    local use_absolute = require("opencode.config").opts.absolute_paths
+    -- `:p` expands to full path, `:." makes relative to CWD
+    local path = vim.fn.fnamemodify(raw_path, use_absolute and ":p" or ":.")
     -- Must be preceeded by @ and followed by space for `opencode` to parse as a file reference
-    result = "@" .. rel_path .. " "
+    result = "@" .. path .. " "
   end
   if args.start_line and args.end_line and args.start_line > args.end_line then
     args.start_line, args.end_line = args.end_line, args.start_line


### PR DESCRIPTION
## Summary
Add `absolute_paths` config option for file path formatting in contexts.

## Problem
The plugin allows connecting to opencode instances in subdirectories of 
Neovim's CWD, but relative paths don't resolve correctly in that case.
When opencode wasn't in the exact same directory as Neovim, the model 
returned gibberish because it couldn't read the referenced files.

## Solution
New `absolute_paths = true` option uses full paths instead of CWD-relative paths.

## Usage
```lua
vim.g.opencode_opts = { absolute_paths = true }
```