### PR TITLE
fix(client): use jobstart for SSE streaming

### DIFF
--- a/lua/opencode/cli/client.lua
+++ b/lua/opencode/cli/client.lua
@@ -101,6 +101,7 @@ local function curl(url, method, body, callback)
   end
 
   local stderr_lines = {}
+  -- Would prefer `vim.system`, but it seems unable to handle rapid SSEs currently and occasionally drops them.
   return vim.fn.jobstart(command, {
     on_stdout = function(_, data)
       if not data then


### PR DESCRIPTION
Fixes #44, previous fix seems not to always work and the issue persists.

Replaces vim.system with vim.fn.jobstart. jobstart streams data as it comes in while vim.system seems to buffer more aggressively occasionally missing events.