### PR TITLE
fix(tmux): create active pane to prevent OSC response leaking into Neovim buffer

### DIFF
--- a/lua/opencode/provider/tmux.lua
+++ b/lua/opencode/provider/tmux.lua
@@ -73,9 +73,9 @@ end
 function Tmux:start()
   local pane_id = self:get_pane_id()
   if not pane_id then
-    -- Create new pane
+    -- Create new pane and make it active to prevent OSC responses from leaking to Neovim
     self.pane_id =
-      vim.fn.system(string.format("tmux split-window -d -P -F '#{pane_id}' %s '%s'", self.opts.options, self.cmd))
+      vim.fn.system(string.format("tmux split-window -P -F '#{pane_id}' %s '%s'", self.opts.options or "", self.cmd))
   end
 end
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

with Ghostty terminal and `allow-passthrough` configured in tmux when I launch opencode it pastes `=31337;OK` into my Neovim buffer. As a workaround we can make the new tmux pane active so that opencode receives the response instead of Neovim.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

https://github.com/NickvanDyke/opencode.nvim/issues/116#issuecomment-3794841142

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
