### PR TITLE
Fix repository name for opencode.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Integrate the [opencode](https://github.com/sst/opencode) AI assistant with Neov
 
 ```lua
 {
-  "NickvanDyke/opencode.nvim",
+  "nickjvandyke/opencode.nvim",
   dependencies = {
     -- Recommended for `ask()` and `select()`.
     -- Required for `snacks` provider.


### PR DESCRIPTION
## Description

This pull request updates the plugin reference in the `README.md` to point to the correct GitHub username for the `opencode.nvim` plugin.

* Documentation update:
  * Changed the plugin reference from `"NickvanDyke/opencode.nvim"` to `"nickjvandyke/opencode.nvim"` in the Lua configuration example in `README.md` to reflect the correct GitHub repository.
