### PR TITLE
fix(tmux) Added extra ways of preventing hanging opencode instances

### DIFF
--- a/lua/opencode/provider/tmux.lua
+++ b/lua/opencode/provider/tmux.lua
@@ -106,7 +106,7 @@ function Tmux:start()
   end
 end
 
----Kill the `opencode` pane and its process.
+---Kill the `opencode` pane.
 function Tmux:stop()
   local pane_id = self:get_pane_id()
   if pane_id then


### PR DESCRIPTION
1. By trimming the return value of `tmux split-window` we ensure that no newline gets added to self.pane_id which always has the potential for weird behaviour

2. We're basically "doubly killing" the opencode pane now by first retrieving his PID. Should `tmux kill-pane` somehow fail an immediate `kill` should do the trick.

3. By moving the autocmd from VimLeave to VimLeavePre the command actually fires in case of a e.g. :q!

## Description

When having an opencode instance running and you quit out with :q! (before you quit the opencode instance via e.g. Ctrl+c), you are left with an orphaned process that at the same time prevents the spawning of OC instances in ANY nvim instance (with the message "Response decode error: Not Found; Vim:E474: Unidentified byte: Not Found"

## Related Issue(s)
#118 


