### PR TITLE
fix(server): prevent connecting to other instances when port is explicitly configured

### DIFF
--- a/lua/opencode/cli/server.lua
+++ b/lua/opencode/cli/server.lua
@@ -222,7 +222,12 @@ function M.get(launch)
   local Promise = require("opencode.promise")
   return get_connected_server()
     :catch(get_configured_server)
-    :catch(M.select)
+    :catch(function(err)
+      if require("opencode.config").opts.port then
+        return Promise.reject(err)
+      end
+      return M.select(err)
+    end)
     :catch(function(err)
       if not err then
         -- Do nothing when select is cancelled


### PR DESCRIPTION
Fixes an issue where opencode connects to an existing instance in the same directory even if a specific unique port is configured for the current nvim instance.

This change ensures that if `opts.port` is set, `opencode` will strictly attempt to connect to that port or launch a new server, skipping the discovery of other running instances via `M.select`.