### PR TITLE
Clean exit for tmux provider

### DIFF
--- a/lua/opencode/provider/tmux.lua
+++ b/lua/opencode/provider/tmux.lua
@@ -110,6 +110,7 @@ end
 function Tmux:stop()
   local pane_id = self:get_pane_id()
   if pane_id then
+    -- HACK: https://github.com/nickjvandyke/opencode.nvim/issues/118
     vim.fn.system("tmux send-keys -t " .. pane_id .. " C-c")
     self.pane_id = nil
   end


### PR DESCRIPTION
## Description

To have clean exit when using tmux as provider, as mentioned [here](https://github.com/nickjvandyke/opencode.nvim/issues/118#issuecomment-3885448538)

> Explicitly stop opencode via Ctrl-C in its TUI, and/or run it outside Neovim so it doesn't orphan every time you exit Neovim.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
- Fixes #118

## Screenshots/Videos

<!-- Add screenshots or videos of the changes if applicable. -->
n/a

