### PR TITLE
Return only processes with ports in unix.get()

### DIFF
--- a/lua/opencode/cli/process/unix.lua
+++ b/lua/opencode/cli/process/unix.lua
@@ -51,19 +51,15 @@ function M.get()
   -- but that misses servers started by "bun" or "node" (or who knows what else) :(
   local pgrep = vim.system({ "pgrep", "-f", "opencode .*--port" }, { text = true }):wait()
   require("opencode.util").check_system_call(pgrep, "pgrep")
-
   local pids = vim.tbl_map(function(line)
     return tonumber(line)
   end, vim.split(pgrep.stdout, "\n", { trimempty = true }))
-  local pids_to_ports = get_ports(pids)
 
+  local pids_to_ports = get_ports(pids)
   ---@type opencode.cli.process.Process[]
   local processes = {}
-  for _, pid in ipairs(pids) do
-    local port = pids_to_ports[pid]
-    if port then
-      table.insert(processes, { pid = pid, port = port })
-    end
+  for pid, port in pairs(pids_to_ports) do
+    table.insert(processes, { pid = pid, port = port })
   end
   return processes
 end


### PR DESCRIPTION
## Description

Prior to this change, the processes returned by `unix.get()` included all processes that matched the `pgrep` command, regardless of whether they had an associated port. This could lead to situations where processes without ports were included in the results, which were then passed to the `client.curl()` function and eventually caused errors when trying to construct a URL with a nil port value.

```
opencode.nvim/lua/opencode/cli/client.lua:53: attempt to concatenate local 'port' (a nil value)
```

This change modifies `unix.get()` to filter out processes that have no associated listening port.

Fix #194
