### PR TITLE
fix(server): handle processes without ports

### DIFF
--- a/lua/opencode/cli/process/init.lua
+++ b/lua/opencode/cli/process/init.lua
@@ -4,7 +4,7 @@ local M = {}
 ---Retrieval is platform-dependent.
 ---@class opencode.cli.process.Process
 ---@field pid number
----@field port number
+---@field port number?
 
 ---@return opencode.cli.process.Process[]
 function M.get()

--- a/lua/opencode/cli/server.lua
+++ b/lua/opencode/cli/server.lua
@@ -25,10 +25,13 @@ local M = {}
 
 ---Verify that an `opencode` process is responding on the given port,
 ---and fetch some details about it.
----@param port number
+---@param port number?
 ---@return Promise<opencode.cli.server.Server>
 local function get_server(port)
   local Promise = require("opencode.promise")
+  if not port then
+    return Promise.reject("This process is not listening on any port.")
+  end
   return Promise
     .new(function(resolve, reject)
       require("opencode.cli.client").get_path(port, function(path)


### PR DESCRIPTION
## Description

Mark the port field as optional in the process definition and update the server logic to reject the promise with a clear error message if a port is not provided because not all processes listen to ports.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots/Videos

<!-- Add screenshots or videos of the changes if applicable. -->

