### PR TITLE
fix(permissions): use synchronous Server instance instead of Promise

### DIFF
--- a/plugin/events/permissions/edits.lua
+++ b/plugin/events/permissions/edits.lua
@@ -17,7 +17,8 @@ vim.api.nvim_create_autocmd("User", {
     ---@type number
     local port = args.data.port
     ---@type opencode.server.Server
-    local server = require("opencode.server").new(port)
+    local Server = require("opencode.server")
+    local server = setmetatable({ port = port }, { __index = Server })
 
     local opts = require("opencode.config").opts.events.permissions or {}
     if not opts.enabled or not opts.edits.enabled then

--- a/plugin/events/permissions/init.lua
+++ b/plugin/events/permissions/init.lua
@@ -19,7 +19,8 @@ vim.api.nvim_create_autocmd("User", {
     ---@type number
     local port = args.data.port
     ---@type opencode.server.Server
-    local server = require("opencode.server").new(port)
+    local Server = require("opencode.server")
+    local server = setmetatable({ port = port }, { __index = Server })
 
     local opts = require("opencode.config").opts.events.permissions or {}
     if not opts.enabled then


### PR DESCRIPTION
## Summary

- Fixes `attempt to call method 'permit' (a nil value)` error when accepting/rejecting permission requests
- `Server.new(port)` was refactored to return a Promise (async validation), but the permission handlers in `plugin/events/permissions/init.lua` and `plugin/events/permissions/edits.lua` use the return value directly as a Server object
- Creates the Server instance directly with `setmetatable` since the server is already known-valid (we received an SSE event from it) — we only need the port to send the HTTP reply back
- This fix was identified with help from an LLM

Fixes #211