### PR TITLE
fix: use only listed buffers for contexts

### DIFF
--- a/lua/opencode/context.lua
+++ b/lua/opencode/context.lua
@@ -338,8 +338,8 @@ end
 ---All open buffers.
 function Context:buffers()
   local file_list = {}
-  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-    local path = Context.format(buf)
+  for _, buf in ipairs(vim.fn.getbufinfo({ buflisted = 1 })) do
+    local path = Context.format(buf.bufnr)
     if path then
       table.insert(file_list, path)
     end


### PR DESCRIPTION
## Description

Currently, `Context:buffers()` includes unlisted buffers, so buffers closed with :bd and opened by the LSP are still sent to the OpenCode terminal when using `@buffers`. This PR fixes that, so the context reflects the user's active working buffers.

## Related Issue(s)
No issue created

## Screenshots/Videos
I can create a video if requested