### PR TITLE
fix(checkhealth): check minor and patch opencode version

### DIFF
--- a/lua/opencode/health.lua
+++ b/lua/opencode/health.lua
@@ -43,13 +43,20 @@ function M.check()
     local latest_tested_version = "1.2.11"
     local latest_tested_version_parsed = vim.version.parse(latest_tested_version)
     if found_version_parsed and latest_tested_version_parsed then
-      if latest_tested_version_parsed[1] ~= found_version_parsed[1] then
+      local found_major = found_version_parsed[1] or 0
+      local latest_tested_major = latest_tested_version_parsed[1] or 0
+      local found_minor = found_version_parsed[2] or 0
+      local latest_tested_minor = latest_tested_version_parsed[2] or 0
+      local found_patch = found_version_parsed[3] or 0
+      local latest_tested_patch = latest_tested_version_parsed[3] or 0
+
+      if latest_tested_major ~= found_major then
         vim.health.warn(
           "`opencode` version has a `major` version mismatch with latest tested version `"
             .. latest_tested_version
             .. "`: may cause compatibility issues."
         )
-      elseif found_version_parsed[2] < latest_tested_version_parsed[2] then
+      elseif found_minor < latest_tested_minor then
         vim.health.warn(
           "`opencode` version has an older `minor` version than latest tested version `"
             .. latest_tested_version
@@ -58,7 +65,7 @@ function M.check()
             "Update `opencode`.",
           }
         )
-      elseif found_version_parsed[3] < latest_tested_version_parsed[3] then
+      elseif found_minor == latest_tested_minor and found_patch < latest_tested_patch then
         vim.health.warn(
           "`opencode` version has an older `patch` version than latest tested version `"
             .. latest_tested_version


### PR DESCRIPTION
## Description

There's a minor logic error (pun intended!) in the `:checkhealth` logic when comparing the opencode version. When the minor version is larger than the latest tested version, the patched version check is still performed. So, the following cases trigger warning. (see screenshots below):
- The opencode version: 1.3.5
- The tested version: 1.2.11

## Related Issue(s)

It's probably not worth creating an issue just for this lol.

## Screenshots/Videos

### Before

<img width="1558" height="705" alt="image" src="https://github.com/user-attachments/assets/63f6d395-575c-409a-877a-9ad07f347f40" />

### After
<img width="1018" height="596" alt="image" src="https://github.com/user-attachments/assets/db388c62-78cd-45b3-999d-6e50d75e2925" />

