### PR TITLE
allow terminal setup to preserve backend focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ local snacks_terminal_opts = {
     position = 'right',
     enter = false,
     on_win = function(win)
-      -- Set up keymaps and cleanup for an arbitrary terminal
-      require('opencode.terminal').setup(win.win)
+      -- Set up keymaps and cleanup for an arbitrary terminal.
+      -- `restore_focus = false` preserves the terminal backend's focus choice.
+      require('opencode.terminal').setup(win.win, { restore_focus = false })
     end,
   },
 }

--- a/lua/opencode/terminal.lua
+++ b/lua/opencode/terminal.lua
@@ -164,7 +164,7 @@ function M.setup(win, opts)
         if opts.restore_focus then
           vim.cmd([[startinsert | call feedkeys("\<C-\>\<C-n>\<C-w>p", "n")]])
         else
-          vim.cmd([[startinsert | call feedkeys("\<C-\>\<C-n>", "n")]])
+          vim.cmd("startinsert")
         end
       end
     end,

--- a/lua/opencode/terminal.lua
+++ b/lua/opencode/terminal.lua
@@ -1,6 +1,8 @@
 local M = {}
 
 ---@class opencode.terminal.Opts : vim.api.keyset.win_config
+---@class opencode.terminal.SetupOpts
+---@field restore_focus? boolean Return focus to the previously focused window after the initial redraw workaround. Defaults to true.
 
 local winid
 local bufnr
@@ -126,7 +128,12 @@ end
 --- - Keymaps for Neovim-like message navigation.
 --- - Properly clean up `opencode` process on close.
 ---@param win integer
-function M.setup(win)
+---@param opts? opencode.terminal.SetupOpts
+function M.setup(win, opts)
+  opts = vim.tbl_extend("keep", opts or {}, {
+    restore_focus = true,
+  })
+
   local buf = vim.api.nvim_win_get_buf(win)
   ---@type integer|nil
   local pid
@@ -154,7 +161,11 @@ function M.setup(win)
       if ev.data.cursor[1] > 1 then
         vim.api.nvim_del_autocmd(auid)
         vim.api.nvim_set_current_win(win)
-        vim.cmd([[startinsert | call feedkeys("\<C-\>\<C-n>\<C-w>p", "n")]])
+        if opts.restore_focus then
+          vim.cmd([[startinsert | call feedkeys("\<C-\>\<C-n>\<C-w>p", "n")]])
+        else
+          vim.cmd([[startinsert | call feedkeys("\<C-\>\<C-n>", "n")]])
+        end
       end
     end,
   })


### PR DESCRIPTION
Hey @nickjvandyke!

I started customizing the plugin to open in a float as I am improving my workflow with ai. I noticed that I could not set the cursor to stay in my newly opened float because of the `setup` method. Do you mind if we made it configurable to do so?

## Summary
- add an optional `restore_focus` flag to `opencode.terminal.setup()` while keeping the current behavior as the default
- let custom terminal integrations preserve their own focus behavior by calling `setup(win, { restore_focus = false })`
- update the README `snacks.terminal` example to show how to opt out of the forced focus restore

## Why
Custom terminal backends may want to control whether focus stays in the terminal or returns to the previous window. The current `setup()` helper always restores focus as part of its redraw workaround, which makes it hard for custom integrations to keep the terminal focused.