### PR TITLE
fix(server): emit one process entry per (PID, port) pair

### DIFF
--- a/lua/opencode/server/process/unix.lua
+++ b/lua/opencode/server/process/unix.lua
@@ -1,9 +1,9 @@
 local M = {}
 
 ---@param pids number[]
----@return table<number, number>
-local function get_ports(pids)
-  assert(#pids > 0, "`get_ports` should only be called with a non-empty list of PIDs to filter by")
+---@return opencode.server.process.Process[]
+local function get_processes_with_ports(pids)
+  assert(#pids > 0, "`get_processes` should only be called with a non-empty list of PIDs to filter by")
 
   local lsof = vim
     .system({
@@ -23,7 +23,8 @@ local function get_ports(pids)
     :wait()
   require("opencode.util").check_system_call(lsof, "lsof")
 
-  local pids_to_ports = {}
+  ---@type opencode.server.process.Process[]
+  local processes = {}
   local pid
   for line in lsof.stdout:gmatch("[^\n]+") do
     local prefix = line:sub(1, 1)
@@ -33,14 +34,16 @@ local function get_ports(pids)
       -- PID line
       pid = tonumber(value)
     elseif prefix == "n" then
-      -- Network interface line - look for ":PORT" at the end of the string
+      -- Network interface line - look for ":PORT" at the end of the string.
+      -- Emit one process entry per (PID, port) since a single PID may listen on multiple ports.
       local port = tonumber(value:match(":(%d+)$"))
-      -- Associate the port with the most recently seen PID (they're always in this order)
-      pids_to_ports[pid] = port
+      if port then
+        processes[#processes + 1] = { pid = pid, port = port }
+      end
     end
   end
 
-  return pids_to_ports
+  return processes
 end
 
 ---@return opencode.server.process.Process[]
@@ -61,13 +64,7 @@ function M.get()
     return {}
   end
 
-  local pids_to_ports = get_ports(pids)
-  ---@type opencode.server.process.Process[]
-  local processes = {}
-  for pid, port in pairs(pids_to_ports) do
-    table.insert(processes, { pid = pid, port = port })
-  end
-  return processes
+  return get_processes_with_ports(pids)
 end
 
 return M


### PR DESCRIPTION
## Tasks

- [x] I read [CONTRIBUTING.md](https://github.com/nickjvandyke/opencode.nvim/blob/main/CONTRIBUTING.md)
- [x] I filled out this PR template
- [x] I reviewed AI-generated code myself
- [x] I made sure my changes pass automated checks
- [x] I responded to and/or resolved automated PR comments

## Description

A single `opencode` PID can listen on multiple ports (e.g. when its TUI and HTTP server bind separately, or when multiple listeners are opened during startup). The previous `get_ports` implementation in `lua/opencode/server/process/unix.lua` collected results into a `pids_to_ports` map keyed by PID, so each new port for the same PID overwrote the previous one. Only the last port emitted by `lsof` survived, and any earlier listening ports for that PID were silently dropped from server discovery.

This change replaces the PID-keyed map with a flat list of `{ pid, port }` entries, appending one entry per port reported by `lsof`. Every listening port now surfaces to the discovery layer, which already deals in `opencode.server.process.Process[]`.

While here:

- Renamed `get_ports` to `get_processes_with_ports` to reflect the new return shape.
- Added a `nil` guard on the parsed port so malformed `lsof` lines do not insert a `{ pid, port = nil }` entry.
- Removed the now-redundant map-to-list conversion in `M.get`, which just forwards the helper's return value.

No public API changes; the function is local to the module and `M.get` keeps its existing return type.

## Related Issue(s)
<img width="939" height="577" alt="image" src="https://github.com/user-attachments/assets/500778f7-b2a2-4ff0-b298-82b75468baf3" />

