### PR TITLE
fix(server): treat non-JSON HTTP responses as request failures

### DIFF
--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -114,6 +114,15 @@ function Server:curl(path, method, body, on_success, on_error, opts)
 
   table.insert(command, url)
 
+  local function on_error_wrapper(code, msg)
+    if on_error then
+      on_error(code, msg)
+    else
+      -- TODO: Eventually all errors should go through `on_error` for higher-level handling
+      vim.notify(msg, vim.log.levels.ERROR, { title = "opencode" })
+    end
+  end
+
   local response_buffer = {}
   local function process_response_buffer()
     if #response_buffer > 0 then
@@ -132,11 +141,7 @@ function Server:curl(path, method, body, on_success, on_error, opts)
             .. full_event
             .. "\nError: "
             .. result
-          if on_error then
-            on_error(-1, error_message)
-          else
-            vim.notify(error_message, vim.log.levels.ERROR, { title = "opencode" })
-          end
+          on_error_wrapper(-1, error_message)
         end
       end)
     end
@@ -173,18 +178,14 @@ function Server:curl(path, method, body, on_success, on_error, opts)
         local response_message = #response_buffer > 0 and table.concat(response_buffer, "\n") or nil
         local stderr_message = #stderr_lines > 0 and table.concat(stderr_lines, "\n") or nil
         local detail_lines = { "Request to " .. url .. " failed with exit code: " .. code }
-        if stderr_message and stderr_message ~= "" then
-          table.insert(detail_lines, "stderr:\n" .. stderr_message)
-        end
         if response_message and response_message ~= "" then
-          table.insert(detail_lines, "response:\n" .. response_message)
+          table.insert(detail_lines, "Response:\n" .. response_message)
+        end
+        if stderr_message and stderr_message ~= "" then
+          table.insert(detail_lines, "Stderr:\n" .. stderr_message)
         end
         local error_message = table.concat(detail_lines, "\n")
-        if on_error then
-          on_error(code, error_message)
-        else
-          vim.notify(error_message, vim.log.levels.ERROR, { title = "opencode" })
-        end
+        on_error_wrapper(code, error_message)
       end
     end,
   })

--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -226,8 +226,8 @@ end
 ---@field mode "primary"|"subagent"
 
 ---@param callback fun(agents: opencode.server.Agent[])
-function Server:get_agents(callback, on_error)
-  return self:curl("/agent", "GET", nil, callback, on_error)
+function Server:get_agents(callback)
+  return self:curl("/agent", "GET", nil, callback)
 end
 
 ---@class opencode.server.Command
@@ -240,8 +240,8 @@ end
 ---However, currently it does not seem to support executing these commands.
 ---
 ---@param callback fun(commands: opencode.server.Command[])
-function Server:get_commands(callback, on_error)
-  return self:curl("/command", "GET", nil, callback, on_error)
+function Server:get_commands(callback)
+  return self:curl("/command", "GET", nil, callback)
 end
 
 ---@class opencode.server.SessionTime
@@ -256,8 +256,8 @@ end
 ---Get sessions from `opencode`.
 ---
 ---@param callback fun(sessions: opencode.server.Session[])
-function Server:get_sessions(callback, on_error)
-  return self:curl("/session", "GET", nil, callback, on_error)
+function Server:get_sessions(callback)
+  return self:curl("/session", "GET", nil, callback)
 end
 
 ---Select session in `opencode`.

--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -23,8 +23,8 @@
 local Server = {}
 Server.__index = Server
 
----Attempt to connect to an `opencode` server process and fetch its details.
----Rejects if connection or fetching details fails.
+---Attempt to connect to an `opencode` server and fetch its details.
+---Rejects if the connection or requests fail — the last line of defense against false-positive server discovery.
 ---@param port number
 ---@return Promise<opencode.server.Server>
 function Server.new(port)
@@ -238,7 +238,6 @@ end
 ---However, currently it does not seem to support executing these commands.
 ---
 ---@param callback fun(commands: opencode.server.Command[])
----@param on_error? fun(code: number, msg: string?)
 function Server:get_commands(callback, on_error)
   return self:curl("/command", "GET", nil, callback, on_error)
 end
@@ -258,16 +257,6 @@ end
 ---@param on_error? fun(code: number, msg: string?)
 function Server:get_sessions(callback, on_error)
   return self:curl("/session", "GET", nil, callback, on_error)
-end
-
----@class opencode.server.SessionStatus
-
----Get sessions' status from `opencode`.
----
----@param callback fun(statuses: opencode.server.SessionStatus[])
----@param on_error? fun(code: number, msg: string?)
-function Server:get_sessions_status(callback, on_error)
-  return self:curl("/session/status", "GET", nil, callback, on_error)
 end
 
 ---Select session in `opencode`.

--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -30,6 +30,7 @@ Server.__index = Server
 function Server.new(port)
   local self = setmetatable({ port = port }, Server)
   local Promise = require("opencode.promise")
+  local unavailable_message = "No `opencode` responding on port: " .. port
 
   return Promise.new(function(resolve, reject)
     self:get_path(function(path)
@@ -37,27 +38,31 @@ function Server.new(port)
       if cwd then
         resolve(cwd)
       else
-        reject("No `opencode` responding on port: " .. port)
+        reject(unavailable_message)
       end
     end, function()
-      reject("No `opencode` responding on port: " .. port)
+      reject(unavailable_message)
     end)
   end)
     :next(function(cwd) ---@param cwd string
       return Promise.all({
         cwd,
-        Promise.new(function(resolve)
+        Promise.new(function(resolve, reject)
           self:get_sessions(function(session)
             local title = session[1] and session[1].title or "<No sessions>"
             resolve(title)
+          end, function(_, msg)
+            reject(msg or unavailable_message)
           end)
         end),
-        Promise.new(function(resolve)
+        Promise.new(function(resolve, reject)
           self:get_agents(function(agents)
             local subagents = vim.tbl_filter(function(agent)
               return agent.mode == "subagent"
             end, agents)
             resolve(subagents)
+          end, function(_, msg)
+            reject(msg or unavailable_message)
           end)
         end),
       })
@@ -87,6 +92,8 @@ function Server:curl(path, method, body, on_success, on_error, opts)
   local command = {
     "curl",
     "-s",
+    "-S",
+    "--fail",
     "-X",
     method,
     "-H",
@@ -122,11 +129,12 @@ function Server:curl(path, method, body, on_success, on_error, opts)
             on_success(response)
           end
         else
-          vim.notify(
-            "Response decode error: " .. full_event .. "; " .. response,
-            vim.log.levels.ERROR,
-            { title = "opencode" }
-          )
+          local error_message = "Failed to decode response from " .. url .. ": " .. response
+          if on_error then
+            on_error(-1, error_message .. "\nresponse:\n" .. full_event)
+          else
+            vim.notify(error_message .. "\nresponse:\n" .. full_event, vim.log.levels.ERROR, { title = "opencode" })
+          end
         end
       end)
     end
@@ -160,14 +168,19 @@ function Server:curl(path, method, body, on_success, on_error, opts)
       if code == 0 then
         process_response_buffer()
       else
+        local response_message = #response_buffer > 0 and table.concat(response_buffer, "\n") or nil
         local stderr_message = #stderr_lines > 0 and table.concat(stderr_lines, "\n") or nil
+        local detail_lines = { "Request to " .. url .. " failed with exit code: " .. code }
+        if stderr_message and stderr_message ~= "" then
+          table.insert(detail_lines, "stderr:\n" .. stderr_message)
+        end
+        if response_message and response_message ~= "" then
+          table.insert(detail_lines, "response:\n" .. response_message)
+        end
+        local error_message = table.concat(detail_lines, "\n")
         if on_error then
-          on_error(code, stderr_message)
+          on_error(code, error_message)
         else
-          local error_message = "curl command failed with exit code: "
-            .. code
-            .. "\nstderr:\n"
-            .. (stderr_message or "<none>")
           vim.notify(error_message, vim.log.levels.ERROR, { title = "opencode" })
         end
       end
@@ -210,8 +223,9 @@ end
 ---@field mode "primary"|"subagent"
 
 ---@param callback fun(agents: opencode.server.Agent[])
-function Server:get_agents(callback)
-  return self:curl("/agent", "GET", nil, callback)
+---@param on_error? fun(code: number, msg: string?)
+function Server:get_agents(callback, on_error)
+  return self:curl("/agent", "GET", nil, callback, on_error)
 end
 
 ---@class opencode.server.Command
@@ -224,8 +238,9 @@ end
 ---However, currently it does not seem to support executing these commands.
 ---
 ---@param callback fun(commands: opencode.server.Command[])
-function Server:get_commands(callback)
-  return self:curl("/command", "GET", nil, callback)
+---@param on_error? fun(code: number, msg: string?)
+function Server:get_commands(callback, on_error)
+  return self:curl("/command", "GET", nil, callback, on_error)
 end
 
 ---@class opencode.server.SessionTime
@@ -240,8 +255,9 @@ end
 ---Get sessions from `opencode`.
 ---
 ---@param callback fun(sessions: opencode.server.Session[])
-function Server:get_sessions(callback)
-  return self:curl("/session", "GET", nil, callback)
+---@param on_error? fun(code: number, msg: string?)
+function Server:get_sessions(callback, on_error)
+  return self:curl("/session", "GET", nil, callback, on_error)
 end
 
 ---@class opencode.server.SessionStatus
@@ -249,8 +265,9 @@ end
 ---Get sessions' status from `opencode`.
 ---
 ---@param callback fun(statuses: opencode.server.SessionStatus[])
-function Server:get_sessions_status(callback)
-  return self:curl("/session/status", "GET", nil, callback)
+---@param on_error? fun(code: number, msg: string?)
+function Server:get_sessions_status(callback, on_error)
+  return self:curl("/session/status", "GET", nil, callback, on_error)
 end
 
 ---Select session in `opencode`.

--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -33,6 +33,7 @@ function Server.new(port)
   local unavailable_message = "No `opencode` responding on port: " .. port
 
   return Promise.new(function(resolve, reject)
+    -- Serially get path first to confirm that this is a valid `opencode` server before making other requests in parallel
     self:get_path(function(path)
       local cwd = path.directory or path.worktree
       if cwd then
@@ -47,22 +48,18 @@ function Server.new(port)
     :next(function(cwd) ---@param cwd string
       return Promise.all({
         cwd,
-        Promise.new(function(resolve, reject)
+        Promise.new(function(resolve)
           self:get_sessions(function(session)
             local title = session[1] and session[1].title or "<No sessions>"
             resolve(title)
-          end, function(_, msg)
-            reject(msg or unavailable_message)
           end)
         end),
-        Promise.new(function(resolve, reject)
+        Promise.new(function(resolve)
           self:get_agents(function(agents)
             local subagents = vim.tbl_filter(function(agent)
               return agent.mode == "subagent"
             end, agents)
             resolve(subagents)
-          end, function(_, msg)
-            reject(msg or unavailable_message)
           end)
         end),
       })
@@ -223,7 +220,6 @@ end
 ---@field mode "primary"|"subagent"
 
 ---@param callback fun(agents: opencode.server.Agent[])
----@param on_error? fun(code: number, msg: string?)
 function Server:get_agents(callback, on_error)
   return self:curl("/agent", "GET", nil, callback, on_error)
 end
@@ -254,7 +250,6 @@ end
 ---Get sessions from `opencode`.
 ---
 ---@param callback fun(sessions: opencode.server.Session[])
----@param on_error? fun(code: number, msg: string?)
 function Server:get_sessions(callback, on_error)
   return self:curl("/session", "GET", nil, callback, on_error)
 end

--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -88,9 +88,9 @@ function Server:curl(path, method, body, on_success, on_error, opts)
 
   local command = {
     "curl",
-    "-s",
-    "-S",
-    "--fail",
+    "-s", -- Silent
+    "-S", -- Except for errors/stderr
+    "--fail-with-body",
     "-X",
     method,
     "-H",

--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -120,17 +120,22 @@ function Server:curl(path, method, body, on_success, on_error, opts)
       local full_event = table.concat(response_buffer)
       response_buffer = {}
       vim.schedule(function()
-        local ok, response = pcall(vim.fn.json_decode, full_event)
+        local ok, result = pcall(vim.fn.json_decode, full_event)
         if ok then
           if on_success then
-            on_success(response)
+            on_success(result)
           end
         else
-          local error_message = "Failed to decode response from " .. url .. ": " .. response
+          local error_message = "Failed to decode response from "
+            .. url
+            .. "\nResponse: "
+            .. full_event
+            .. "\nError: "
+            .. result
           if on_error then
-            on_error(-1, error_message .. "\nresponse:\n" .. full_event)
+            on_error(-1, error_message)
           else
-            vim.notify(error_message .. "\nresponse:\n" .. full_event, vim.log.levels.ERROR, { title = "opencode" })
+            vim.notify(error_message, vim.log.levels.ERROR, { title = "opencode" })
           end
         end
       end)


### PR DESCRIPTION
## Tasks

- [x] I read [CONTRIBUTING.md](https://github.com/nickjvandyke/opencode.nvim/blob/main/CONTRIBUTING.md)
- [x] I filled out this PR template
- [x] I reviewed AI-generated code myself
- [x] I made sure my changes pass automated checks
- [x] I responded to and/or resolved automated PR comments

## Description

Fix misleading response decode errors when probing invalid or non-opencode endpoints.

When `opencode.nvim` probes a port that responds with a plain-text HTTP error body such as `Not Found`, the plugin currently attempts to decode that body as JSON and surfaces a confusing `Vim:E474` decode error.

This change makes HTTP failures go through the error path instead of the JSON decode path by using `curl --fail`, and it also treats non-JSON response bodies as request failures. This allows server discovery to reject invalid targets cleanly without showing a misleading decode error.

### Additional Impact

4xx/5xx HTTP responses are now treated as request failures instead of successful responses.

## Related Issue(s)

- Fixes #241 

## Screenshots/Videos

<!-- Add screenshots or videos of the changes if applicable. -->

Not applicable for this change.