### PR TITLE
fix: process discovery on NixOS

### DIFF
--- a/lua/opencode/server/process/unix.lua
+++ b/lua/opencode/server/process/unix.lua
@@ -54,7 +54,9 @@ function M.get()
   -- Filter by `--port` because it's required to expose the server.
   -- We can aaaalmost skip this and just use "-c opencode" with `lsof`,
   -- but that misses servers started by "bun" or "node" (or who knows what else) :(
-  local pgrep = vim.system({ "pgrep", "-f", "opencode .*--port" }, { text = true }):wait()
+  -- Also we should consider that on Nix binary can be called "opencode-wrapped"
+  -- (so we cannot do "opencode .*--port").
+  local pgrep = vim.system({ "pgrep", "-f", "opencode.*--port" }, { text = true }):wait()
   require("opencode.util").check_system_call(pgrep, "pgrep")
   local pids = vim.tbl_map(function(line)
     return tonumber(line)


### PR DESCRIPTION
## Tasks

<!--
  I am happy to provide feedback and iterate together!
  Please complete these tasks to make it easier for both of us.
  Note that the automated checks and review run _after_ you open the PR.
-->

- [x] I read [CONTRIBUTING.md](https://github.com/nickjvandyke/opencode.nvim/blob/main/CONTRIBUTING.md)
- [x] I reviewed AI-generated code myself
- [x] I made sure my changes pass automated checks
- [ ] I responded to and/or addressed automated review comments (if any)

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

On NixOS `ps -au` can return the following line for OpenCode:

```
ffloyd    326815  5.4  1.2 74522096 411196 pts/2 Ssl+ 16:16   0:11 /nix/store/aqdisqwd5bxp8szz9nrg9sz0d24knmnp-opencode-adjusted/bin/.opencode-wrapped_ --port
```

It happens because Nix often use wrappers. The pgrep pattern should be adjusted. Otherwise - no OpenCode process can be found by the plugin.

Theoretically, it can lead to false-positives, but I suspect it's not a big problem.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots/Videos

<!-- Add screenshots or videos of the changes if applicable. -->

