### PR TITLE
fix: narrow pgrep regex so wrappers (proxy-tool, npm/npx, node) are n…

### DIFF
--- a/lua/opencode/cli/client.lua
+++ b/lua/opencode/cli/client.lua
@@ -83,6 +83,10 @@ local function curl(url, method, body, on_success, on_error)
           if on_success then
             on_success(response)
           end
+        elseif on_error then
+          -- Caller is doing speculative probing (e.g. server discovery) - let it
+          -- decide whether the failure is interesting; don't pop a global notify.
+          on_error(0, "Response decode error: " .. full_event .. "; " .. response)
         else
           vim.notify(
             "Response decode error: " .. full_event .. "; " .. response,

--- a/lua/opencode/cli/server.lua
+++ b/lua/opencode/cli/server.lua
@@ -20,8 +20,12 @@ end
 ---@return opencode.cli.server.Process[]
 local function get_processes_unix()
   -- Find PIDs by command line pattern.
-  -- We filter for `--port` to avoid matching other `opencode`-related processes (LSPs etc.)
-  local pgrep = vim.system({ "pgrep", "-f", "opencode.*--port" }, { text = true }):wait()
+  -- We filter for `--port` to avoid matching other `opencode`-related processes (LSPs etc.).
+  -- The leading `[^ ]*` constrains the match to processes whose argv[0] ends in `opencode`,
+  -- so wrappers/launchers that happen to mention `opencode` somewhere later in their argv
+  -- (e.g. `proxy-tool exec -- npx -y opencode-ai@latest --port`, `npm exec opencode-ai@latest`,
+  -- `node .../opencode-ai/bin/.opencode --port`) don't get picked up.
+  local pgrep = vim.system({ "pgrep", "-f", "^[^ ]*opencode --port" }, { text = true }):wait()
   require("opencode.util").check_system_call(pgrep, "pgrep")
 
   local processes = {}


### PR DESCRIPTION
## Tasks

<!--
  I am happy to provide feedback and iterate together!
  Please complete these tasks to make it easier for both of us.
  Note that the automated checks and review run _after_ you open the PR.
-->

- [X] I read [CONTRIBUTING.md](https://github.com/nickjvandyke/opencode.nvim/blob/main/CONTRIBUTING.md)
- [X] I reviewed AI-generated code myself
- [X] I made sure my changes pass automated checks
- [ ] I responded to and/or addressed automated review comments (if any)

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

The previous regex 'opencode.*--port' matched any process whose full command line contained those tokens in order. In environments where opencode is launched through wrappers (e.g. 'proxy-tool exec -- npx -y opencode-ai@latest --port ...'), wrapper processes such as proxy-tool, npm, and the node launcher all match. Some of them also listen on a TCP port (proxy-tool runs an HTTP forward proxy), so the subsequent lsof + curl /path probing hit them, producing spurious 'Response decode error' notifications and visible errors in the embedded TUI (e.g. 'ERROR proxy_tool > GET /path - unsupported').

Anchor the regex to argv[0] and require it to end in 'opencode' so only the real opencode binary matches. Also route JSON-decode failures through on_error when the caller provides one, so speculative server discovery doesn't pop a global notification on every non-opencode port that happens to respond.
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots/Videos

<!-- Add screenshots or videos of the changes if applicable. -->

